### PR TITLE
Escape double-dash in HTML comment

### DIFF
--- a/.github/ISSUE_TEMPLATE/problem.md
+++ b/.github/ISSUE_TEMPLATE/problem.md
@@ -39,7 +39,7 @@ assignees: Yajo
 
 **Environment**
  - OS: <!-- Windows, Mac, Linux... Specify distro and version -->
- - Copier version: <!-- copier --version output -->
+ - Copier version: <!-- copier \-\-version output -->
  - Python version:
  - Installation method: <!-- pipx+pypi, pipx+git, pip+pypi, pip+git, local build, distro package... -->
 


### PR DESCRIPTION
The double-dash in `<!-- ... --version ... -->` now reads `<!-- ... \-\-version ... -->` so that the comment renders properly.